### PR TITLE
feat: use asdf exec-env to set CLOUDSDK_PYTHON on each gcloud cmd use

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@
 # Dependencies
 
 - `bash`, `curl`, `tar`, `python`
-- `CLOUDSDK_PYTHON`: set this environment variable in your shell config to load the correct version of Python.
-
-  ```shell
-  python_sdk="$(command -v python)"
-  export CLOUDSDK_PYTHON="${python_sdk}"
-  ```
 
 # Install
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if ! [ -x "$(command -v python)" ]; then
+    printf " Python not found. Please install python. Might I suggest https://github.com/danhper/asdf-python"
+    exit 1
+fi
+
+if [ "$CLOUDSDK_PYTHON" = "" ]; then
+    python_sdk="$(command -v python)"
+    export CLOUDSDK_PYTHON="${python_sdk}"
+fi

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-if ! [ -x "$(command -v python)" ]; then
+if [ ! -x "$(command -v python)" ]; then
     printf " Python not found. Please install python. Might I suggest https://github.com/danhper/asdf-python"
     exit 1
 fi
 
-if [ "$CLOUDSDK_PYTHON" = "" ]; then
+if [ -n "${CLOUDSDK_PYTHON:-}" ]; then
     python_sdk="$(command -v python)"
     export CLOUDSDK_PYTHON="${python_sdk}"
 fi

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,12 +2,14 @@
 
 set -euo pipefail
 
-if [ ! -x "$(command -v python)" ]; then
-    printf " Python not found. Please install python. Might I suggest https://github.com/danhper/asdf-python"
+if [[ ! -x "$(command -v python)" ]]; then
+    printf "🚨  Python not found and is required for gcloud. Might I suggest https://github.com/danhper/asdf-python\\n"
     exit 1
 fi
 
-if [ -n "${CLOUDSDK_PYTHON:-}" ]; then
+# stolen from https://unix.stackexchange.com/a/56846/397902
+if [ -z "${CLOUDSDK_PYTHON:+1}" ]; then
+    # undefined or defined and empty
     python_sdk="$(command -v python)"
-    export CLOUDSDK_PYTHON="${python_sdk}"
+    export CLOUDSDK_PYTHON=${python_sdk}
 fi

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if ! [ -x "$(command -v python)" ]; then
     printf " Python not found. Please install python. Might I suggest https://github.com/danhper/asdf-python"
     exit 1

--- a/bin/install
+++ b/bin/install
@@ -33,7 +33,6 @@ extract() {
 
 install_gcloud() {
     printf "🚧  installing...\\n"
-    printf "    ⚠️  CLOUDSDK_PYTHON must be set in you shell profile\\n"
     "${ASDF_INSTALL_PATH}/install.sh" --usage-reporting=false --path-update=false --quiet
     printf "✅  gcloud %s installed!\\n" "${ASDF_INSTALL_VERSION}"
 }


### PR DESCRIPTION
asdf `exec-env` is run before each use of the command (in this case `gcloud`). We can use this to set the `CLOUDSDK_PYTHON` env var which is required by `gcloud`.

Implementation:
- guards against missing `python`
- will not override `CLOUDSDK_PYTHON` if already present

Closes #13 