### PR TITLE
fix: uninstall command without using gcloud

### DIFF
--- a/bin/uninstall
+++ b/bin/uninstall
@@ -4,6 +4,6 @@ set -euo pipefail
 
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
-printf "ℹ️  Your gcloud project configuration(s) persist in ~/.config/gcloud\\n"
+printf "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ~/.config/gcloud\\n"
 
 rm -rf "$ASDF_INSTALL_PATH"

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -4,6 +4,4 @@ set -euo pipefail
 
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
-gcloud_config_path=$(gcloud info --format='value(config.paths.global_config_dir)')
-
-printf "ℹ️  Your gcloud project configuration(s) persist in %s\\n" "${gcloud_config_path}"
+printf "ℹ️  Your gcloud project configuration(s) persist in ~/.config/gcloud\\n"

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -5,3 +5,5 @@ set -euo pipefail
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
 printf "ℹ️  Your gcloud project configuration(s) persist in ~/.config/gcloud\\n"
+
+rm -rf "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Shims are removed before the `uninstall` script is called, so `gcloud` is unavailable to use.