### PR TITLE
automatic cloud sdk components install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ asdf global gcloud 286.0.0
 
 The asdf config file, `.tool-versions`, allows pinning each tool in your project to a specific version. This ensures that ALL developers are using the same version of each tool. Same `python`, same `gcloud`, same `terraform` etc.
 
+When you update a version in `.tool-versions`, `asdf` will prompt all users who do not have the correct versions to upgrade. This enables whole teams to update their tools in unison.
+
 # Default Cloud SDK Components
 
 `asdf-gcloud` can automatically install a set of Cloud SDK Components after each `asdf install gcloud <version>`. To enable this feature you must have a file that lists one COMPONENT_ID per line. For example:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The asdf config file, `.tool-versions`, allows pinning each tool in your project
 
 # Default Cloud SDK Components
 
-`asdf-gcloud` can automatically install a set of Cloud SDK Components after each `asdf install gcloud <version>`. To enable this feature, provide a `${HOME}/.config/gcloud/.default-cloud-sdk-components` file that lists one COMPONENT_ID per line. For example:
+`asdf-gcloud` can automatically install a set of Cloud SDK Components after each `asdf install gcloud <version>`. To enable this feature you must have a file that lists one COMPONENT_ID per line. For example:
 
 ```
 alpha
@@ -60,6 +60,12 @@ beta
 cloud-build-local
 cloud-firestore-emulator
 ```
+
+This file must be named `.default-cloud-sdk-components` and be at one of the following locations:
+
+- `$HOME/.config/gcloud/.default-cloud-sdk-components`: next to gcloud auth configurations
+- `$(dirname ASDF_CONFIG_FILE)/.default-cloud-sdk-components`: relative to `.asdfrc` if configured
+- `$HOME/.default-cloud-sdk-components`: Home dir
 
 Below is the list of available components (as of version `286.0.0`):
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Dependencies](#dependencies)
 - [Install](#install)
 - [Why?](#why)
+- [Default Cloud SDK Components](#default-cloud-sdk-components)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -48,6 +49,65 @@ asdf global gcloud 285.0.1
 # Why?
 
 The asdf config file, `.tool-versions`, allows pinning each tool in your project to a specific version. This ensures that ALL developers are using the same version of each tool. Same `python`, same `gcloud`, same `terraform` etc.
+
+# Default Cloud SDK Components
+
+`asdf-gcloud` can automatically install a set of Cloud SDK Components after each `asdf install gcloud <version>`. To enable this feature, provide a `${HOME}/.config/gcloud/.default-cloud-sdk-components` file that lists one COMPONENT_ID per line. For example:
+
+```
+alpha
+beta
+cloud-build-local
+cloud-firestore-emulator
+```
+
+Below is the list of available components (as of version `286.0.0`):
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                 Components                                                 │
+├───────────────┬──────────────────────────────────────────────────────┬──────────────────────────┬──────────┤
+│     Status    │                         Name                         │            ID            │   Size   │
+├───────────────┼──────────────────────────────────────────────────────┼──────────────────────────┼──────────┤
+│ Not Installed │ App Engine Go Extensions                             │ app-engine-go            │  4.8 MiB │
+│ Not Installed │ Appctl                                               │ appctl                   │ 17.5 MiB │
+│ Not Installed │ Cloud Bigtable Command Line Tool                     │ cbt                      │  7.6 MiB │
+│ Not Installed │ Cloud Bigtable Emulator                              │ bigtable                 │  6.6 MiB │
+│ Not Installed │ Cloud Datalab Command Line Tool                      │ datalab                  │  < 1 MiB │
+│ Not Installed │ Cloud Datastore Emulator                             │ cloud-datastore-emulator │ 18.4 MiB │
+│ Not Installed │ Cloud Firestore Emulator                             │ cloud-firestore-emulator │ 40.3 MiB │
+│ Not Installed │ Cloud Pub/Sub Emulator                               │ pubsub-emulator          │ 34.9 MiB │
+│ Not Installed │ Cloud SQL Proxy                                      │ cloud_sql_proxy          │  3.7 MiB │
+│ Not Installed │ Emulator Reverse Proxy                               │ emulator-reverse-proxy   │ 14.5 MiB │
+│ Not Installed │ Google Cloud Build Local Builder                     │ cloud-build-local        │  5.9 MiB │
+│ Not Installed │ Google Container Registry's Docker credential helper │ docker-credential-gcr    │  1.8 MiB │
+│ Not Installed │ Kind                                                 │ kind                     │  4.4 MiB │
+│ Not Installed │ Minikube                                             │ minikube                 │ 21.9 MiB │
+│ Not Installed │ Skaffold                                             │ skaffold                 │ 12.9 MiB │
+│ Not Installed │ anthos-auth                                          │ anthos-auth              │  8.6 MiB │
+│ Not Installed │ gcloud Alpha Commands                                │ alpha                    │  < 1 MiB │
+│ Not Installed │ gcloud Beta Commands                                 │ beta                     │  < 1 MiB │
+│ Not Installed │ gcloud app Java Extensions                           │ app-engine-java          │ 62.3 MiB │
+│ Not Installed │ gcloud app PHP Extensions                            │ app-engine-php           │ 21.9 MiB │
+│ Not Installed │ gcloud app Python Extensions                         │ app-engine-python        │  6.1 MiB │
+│ Not Installed │ gcloud app Python Extensions (Extra Libraries)       │ app-engine-python-extras │ 27.1 MiB │
+│ Not Installed │ kpt                                                  │ kpt                      │ 18.8 MiB │
+│ Not Installed │ kubectl                                              │ kubectl                  │  < 1 MiB │
+│ Installed     │ BigQuery Command Line Tool                           │ bq                       │  < 1 MiB │
+│ Installed     │ Cloud SDK Core Libraries                             │ core                     │ 14.1 MiB │
+│ Installed     │ Cloud Storage Command Line Tool                      │ gsutil                   │  3.6 MiB │
+└───────────────┴──────────────────────────────────────────────────────┴──────────────────────────┴──────────┘
+```
+
+Note: I am considering making this default config file location configurable via an evironment variable. I want to raise a discussion with the `asdf` core team about supporting a config dir first, perhaps `~/.config/asdf`
+
+# FAQ
+
+```
+~/.asdf/lib/commands/command-exec.bash: line 23: shim_args[@]: unbound variable
+```
+
+**This is expected** as `asdf-gcloud` sets the Bash option for `nounset` variables which makes running `gcloud` without commands an error. You should always pass a command to `gcloud`.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ asdf plugin add gcloud
 GCloud:
 
 ```shell
-asdf install gcloud 285.0.1
+asdf install gcloud 286.0.0
 ```
 
 Set global version:
 
 ```shell
-asdf global gcloud 285.0.1
+asdf global gcloud 286.0.0
 ```
 
 # Why?

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -9,7 +9,7 @@ if [[ ! -x "$(command -v python)" ]]; then
     log_failure_and_exit "Python not found and is required for gcloud. Might I suggest https://github.com/danhper/asdf-python"
 fi
 
-# stolen from https://unix.stackexchange.com/a/56846/397902
+# credit: https://unix.stackexchange.com/a/56846/397902
 if [ -z "${CLOUDSDK_PYTHON:+1}" ]; then
     # undefined or defined and empty
     python_sdk="$(command -v python)"

--- a/bin/install
+++ b/bin/install
@@ -44,3 +44,6 @@ fi
 check_dependencies "$(dirname "$0")/../lib/dependencies.txt" "failure"
 
 install_gcloud
+
+# post-install (install .default-cloud-sdk-components)
+bash "$(dirname "$0")/post-install"

--- a/bin/install
+++ b/bin/install
@@ -38,7 +38,7 @@ install_gcloud() {
 }
 
 if [ "${ASDF_INSTALL_TYPE}" != "version" ]; then
-    log_failure_and_exit "Please provide the gcloud version number you wish to install."
+    log_failure_and_exit "Please provide the gcloud version number you wish to install. See \`asdf list all gcloud\`"
 fi
 
 check_dependencies "$(dirname "$0")/../lib/dependencies.txt" "failure"
@@ -47,3 +47,6 @@ install_gcloud
 
 # post-install (install .default-cloud-sdk-components)
 bash "$(dirname "$0")/post-install"
+
+# reshim now sdk components are installed
+asdf reshim "$(get_plugin_name)" "$ASDF_INSTALL_VERSION"

--- a/bin/post-install
+++ b/bin/post-install
@@ -26,6 +26,7 @@ function install_default_cloud_sdk_components() {
     local default_cloud_sdk_components
     default_cloud_sdk_components="$(default_cloud_sdk_components_config_path)"
     local gcloud="${ASDF_INSTALL_PATH}/bin/gcloud"
+    declare -a component_list=()
 
     if [ ! -f "$default_cloud_sdk_components" ]; then
         return
@@ -34,9 +35,11 @@ function install_default_cloud_sdk_components() {
     log_info "ℹ️  Installing SDK Components from ${default_cloud_sdk_components}"
 
     while IFS="" read -r p || [ -n "${p}" ]; do
-        log_info "ℹ️  Installing ${p} SDK Component"
-        $gcloud --quiet components install "${p}"
+        component_list+=("${p}")
     done <"${default_cloud_sdk_components}"
+
+    $gcloud --quiet components install "${component_list[@]}"
+
     log_success "Cloud SDK Components installed"
 }
 

--- a/bin/post-install
+++ b/bin/post-install
@@ -25,13 +25,17 @@ function default_cloud_sdk_components_config_path() {
 function install_default_cloud_sdk_components() {
     local default_cloud_sdk_components
     default_cloud_sdk_components="$(default_cloud_sdk_components_config_path)"
+    local gcloud="${ASDF_INSTALL_PATH}/bin/gcloud"
 
     if [ ! -f "$default_cloud_sdk_components" ]; then
         return
     fi
 
+    log_info "ℹ️  Installing SDK Components from ${default_cloud_sdk_components}"
+
     while IFS="" read -r p || [ -n "${p}" ]; do
-        gcloud components install "${p}"
+        log_info "ℹ️  Installing ${p} SDK Component"
+        $gcloud --quiet components install "${p}"
     done <"${default_cloud_sdk_components}"
     log_success "Cloud SDK Components installed"
 }

--- a/bin/post-install
+++ b/bin/post-install
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=../lib/utils.bash
+source "$(dirname "$0")/../lib/utils.bash"
+
+function default_cloud_sdk_components_config_path() {
+    local default_components_filename=".default-cloud-sdk-components"
+    local default_config_dir="$HOME/.config/gcloud"
+
+    local asdf_config_path="${ASDF_CONFIG_FILE:-"$HOME/.asdfrc"}"
+    local asdf_config_dir
+    asdf_config_dir=$(dirname "$asdf_config_path")
+
+    if [ -f "${default_config_dir}/${default_components_filename}" ]; then
+        echo "${default_config_dir}/${default_components_filename}"
+    elif [ -f "${asdf_config_dir}/${default_components_filename}" ]; then
+        echo "${asdf_config_dir}/${default_components_filename}"
+    else
+        echo "${HOME}/${default_components_filename}"
+    fi
+}
+
+function install_default_cloud_sdk_components() {
+    local default_cloud_sdk_components
+    default_cloud_sdk_components="$(default_cloud_sdk_components_config_path)"
+
+    if [ ! -f "$default_cloud_sdk_components" ]; then
+        return
+    fi
+
+    while IFS="" read -r p || [ -n "${p}" ]; do
+        gcloud components install "${p}"
+    done <"${default_cloud_sdk_components}"
+    log_success "Cloud SDK Components installed"
+}
+
+install_default_cloud_sdk_components

--- a/bin/pre-plugin-remove
+++ b/bin/pre-plugin-remove
@@ -7,4 +7,4 @@ source "$(dirname "$0")/../lib/utils.bash"
 
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
-log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ~/.config/gcloud"
+log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ${HOME}/.config/gcloud"

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -7,6 +7,6 @@ source "$(dirname "$0")/../lib/utils.bash"
 
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
-log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ~/.config/gcloud"
+log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ${HOME}/.config/gcloud"
 
 rm -rf "${ASDF_INSTALL_PATH}"

--- a/lib/dependencies.txt
+++ b/lib/dependencies.txt
@@ -1,4 +1,5 @@
 bash
+basename
 curl
 dirname
 echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -76,3 +76,7 @@ function get_os_name() {
     esac
     echo "${os_name}"
 }
+
+get_plugin_name() {
+    basename "$(dirname "$(dirname "$0")")"
+}


### PR DESCRIPTION
- [x] asdf-gcloud post-install that checks for a .default-cloud-sdk-components` file in multiple locations
- [x] update gcloud version in README
- [x] improve uninstall/plugin-remove logs to be absolute format and therefore rendered as links in certain shells

Closes #18 