### PR TITLE
fix: use custom sort func for portability

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,8 +6,7 @@ on:
   pull_request:
 
 jobs:
-  code_lint:
-    name: Shellcheck and Shell Format
+  shellcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -18,6 +17,16 @@ jobs:
           before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       - name: Shellcheck
         run: shellcheck -x bin/* -P lib/
+
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: asdf_install
+        uses: asdf-vm/actions/install@v1
+        with:
+          before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       - name: Shell Format - List files to check
         run: shfmt -f .
       - name: Shell Format - Validate

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This file must be named `.default-cloud-sdk-components` and be at one of the fol
 - `$(dirname ASDF_CONFIG_FILE)/.default-cloud-sdk-components`: relative to `.asdfrc` if configured
 - `$HOME/.default-cloud-sdk-components`: Home dir
 
-Below is the list of available components (as of version `286.0.0`):
+Below is the list of available components (as of version `342.0.0`):
 
 ```
 ┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -84,33 +84,38 @@ Below is the list of available components (as of version `286.0.0`):
 ├───────────────┬──────────────────────────────────────────────────────┬──────────────────────────┬──────────┤
 │     Status    │                         Name                         │            ID            │   Size   │
 ├───────────────┼──────────────────────────────────────────────────────┼──────────────────────────┼──────────┤
-│ Not Installed │ App Engine Go Extensions                             │ app-engine-go            │  4.8 MiB │
-│ Not Installed │ Appctl                                               │ appctl                   │ 17.5 MiB │
-│ Not Installed │ Cloud Bigtable Command Line Tool                     │ cbt                      │  7.6 MiB │
+│ Not Installed │ App Engine Go Extensions                             │ app-engine-go            │  4.9 MiB │
+│ Not Installed │ Appctl                                               │ appctl                   │ 21.0 MiB │
+│ Not Installed │ Cloud Bigtable Command Line Tool                     │ cbt                      │  7.7 MiB │
 │ Not Installed │ Cloud Bigtable Emulator                              │ bigtable                 │  6.6 MiB │
 │ Not Installed │ Cloud Datalab Command Line Tool                      │ datalab                  │  < 1 MiB │
 │ Not Installed │ Cloud Datastore Emulator                             │ cloud-datastore-emulator │ 18.4 MiB │
-│ Not Installed │ Cloud Firestore Emulator                             │ cloud-firestore-emulator │ 40.3 MiB │
-│ Not Installed │ Cloud Pub/Sub Emulator                               │ pubsub-emulator          │ 34.9 MiB │
-│ Not Installed │ Cloud SQL Proxy                                      │ cloud_sql_proxy          │  3.7 MiB │
+│ Not Installed │ Cloud Firestore Emulator                             │ cloud-firestore-emulator │ 40.5 MiB │
+│ Not Installed │ Cloud Pub/Sub Emulator                               │ pubsub-emulator          │ 60.4 MiB │
+│ Not Installed │ Cloud SQL Proxy                                      │ cloud_sql_proxy          │  7.6 MiB │
+│ Not Installed │ Cloud Spanner Emulator                               │ cloud-spanner-emulator   │ 21.8 MiB │
 │ Not Installed │ Emulator Reverse Proxy                               │ emulator-reverse-proxy   │ 14.5 MiB │
-│ Not Installed │ Google Cloud Build Local Builder                     │ cloud-build-local        │  5.9 MiB │
+│ Not Installed │ Google Cloud Build Local Builder                     │ cloud-build-local        │  6.3 MiB │
 │ Not Installed │ Google Container Registry's Docker credential helper │ docker-credential-gcr    │  1.8 MiB │
-│ Not Installed │ Kind                                                 │ kind                     │  4.4 MiB │
-│ Not Installed │ Minikube                                             │ minikube                 │ 21.9 MiB │
-│ Not Installed │ Skaffold                                             │ skaffold                 │ 12.9 MiB │
-│ Not Installed │ anthos-auth                                          │ anthos-auth              │  8.6 MiB │
+│ Not Installed │ Kustomize                                            │ kustomize                │ 25.9 MiB │
+│ Not Installed │ Minikube                                             │ minikube                 │ 50.4 MiB │
+│ Not Installed │ Nomos CLI                                            │ nomos                    │ 22.9 MiB │
+│ Not Installed │ On-Demand Scanning API extraction helper             │ local-extract            │ 13.6 MiB │
+│ Not Installed │ Skaffold                                             │ skaffold                 │ 16.8 MiB │
+│ Not Installed │ anthos-auth                                          │ anthos-auth              │ 16.8 MiB │
+│ Not Installed │ config-connector                                     │ config-connector         │ 44.6 MiB │
 │ Not Installed │ gcloud Alpha Commands                                │ alpha                    │  < 1 MiB │
 │ Not Installed │ gcloud Beta Commands                                 │ beta                     │  < 1 MiB │
-│ Not Installed │ gcloud app Java Extensions                           │ app-engine-java          │ 62.3 MiB │
-│ Not Installed │ gcloud app PHP Extensions                            │ app-engine-php           │ 21.9 MiB │
+│ Not Installed │ gcloud app Java Extensions                           │ app-engine-java          │ 52.4 MiB │
 │ Not Installed │ gcloud app Python Extensions                         │ app-engine-python        │  6.1 MiB │
 │ Not Installed │ gcloud app Python Extensions (Extra Libraries)       │ app-engine-python-extras │ 27.1 MiB │
-│ Not Installed │ kpt                                                  │ kpt                      │ 18.8 MiB │
+│ Not Installed │ kpt                                                  │ kpt                      │ 11.7 MiB │
 │ Not Installed │ kubectl                                              │ kubectl                  │  < 1 MiB │
+│ Not Installed │ kubectl-oidc                                         │ kubectl-oidc             │ 16.8 MiB │
+│ Not Installed │ pkg                                                  │ pkg                      │          │
 │ Installed     │ BigQuery Command Line Tool                           │ bq                       │  < 1 MiB │
-│ Installed     │ Cloud SDK Core Libraries                             │ core                     │ 14.1 MiB │
-│ Installed     │ Cloud Storage Command Line Tool                      │ gsutil                   │  3.6 MiB │
+│ Installed     │ Cloud SDK Core Libraries                             │ core                     │ 18.6 MiB │
+│ Installed     │ Cloud Storage Command Line Tool                      │ gsutil                   │  3.9 MiB │
 └───────────────┴──────────────────────────────────────────────────────┴──────────────────────────┴──────────┘
 ```
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
 gcs_bucket_name="cloud-sdk-release"
 gcs_object_prefix="google-cloud-sdk"
 gcs_object_fields="kind,nextPageToken,items(name)"

--- a/bin/list-all
+++ b/bin/list-all
@@ -29,4 +29,4 @@ function list_all() {
 	echo -e "${list}"
 }
 
-list_all | sort -V | tr '\n' ' '
+list_all | sort_versions | tr '\n' ' '

--- a/bin/list-all
+++ b/bin/list-all
@@ -35,4 +35,4 @@ function list_all() {
 	echo -e "${list}"
 }
 
-list_all | sort_versions | tr '\n' ' '
+list_all | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -82,7 +82,7 @@ get_plugin_name() {
 }
 
 function sort_versions() {
-	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+	sed 'h; s/[-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' |
 		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n |
 		awk '{print $2}'
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -80,3 +80,9 @@ function get_os_name() {
 get_plugin_name() {
 	basename "$(dirname "$(dirname "$0")")"
 }
+
+function sort_versions() {
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n |
+		awk '{print $2}'
+}

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -83,6 +83,6 @@ get_plugin_name() {
 
 function sort_versions() {
 	sed 'h; s/[-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' |
-		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n |
+		LC_ALL=C sort -t. -k 1,1n -k 2,2n -k 3,3n |
 		awk '{print $2}'
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`sort -V` or `sort --version-sort` are not portable as discovered and documented in the `asdf` core. This PR introduces the workaround.

closes #45 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
