### PR TITLE
feat: support arm builds

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -66,20 +66,25 @@ function get_os_architecture() {
   echo -n $architecture
 }
 
-function get_os_name() {
-	local os_name
-	case $(uname -s) in
-	Linux*)
-		os_name="linux"
+function get_os_architecture() {
+	local architecture
+
+	case "$(uname -m)" in
+	x86_64 | amd64)
+		architecture="x86_64"
 		;;
-	Darwin*)
-		os_name="darwin"
+	i686 | i386)
+		architecture="x86"
+		;;
+	aarch64 | arm64)
+		architecture="arm"
 		;;
 	*)
-		log_failure_and_exit "Script only supports macOS and Ubuntu"
+		log_failure_and_exit "Architecture $(uname -m) not supported!"
 		;;
 	esac
-	echo "${os_name}"
+
+	echo "${architecture}"
 }
 
 get_plugin_name() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -52,7 +52,7 @@ function check_dependencies() {
 }
 
 function get_os_architecture() {
-	local arch=""
+	local architecture
 
   case "$(uname -m)" in
   x86_64 | amd64) architecture="x86_64" ;;

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -52,13 +52,18 @@ function check_dependencies() {
 }
 
 function get_os_architecture() {
-	local architecture
-	if [[ $(getconf LONG_BIT) == "64" ]]; then
-		architecture="x86_64"
-	else
-		architecture="x86"
-	fi
-	echo "${architecture}"
+	local arch=""
+
+  case "$(uname -m)" in
+  x86_64 | amd64) architecture="x86_64" ;;
+  i686 | i386) architecture="x86" ;;
+  aarch64 | arm64) architecture="arm" ;;
+  *)
+    fail "Arch '$(uname -m)' not supported!"
+    ;;
+  esac
+
+  echo -n $architecture
 }
 
 function get_os_name() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -54,21 +54,6 @@ function check_dependencies() {
 function get_os_architecture() {
 	local architecture
 
-  case "$(uname -m)" in
-  x86_64 | amd64) architecture="x86_64" ;;
-  i686 | i386) architecture="x86" ;;
-  aarch64 | arm64) architecture="arm" ;;
-  *)
-    fail "Arch '$(uname -m)' not supported!"
-    ;;
-  esac
-
-  echo -n $architecture
-}
-
-function get_os_architecture() {
-	local architecture
-
 	case "$(uname -m)" in
 	x86_64 | amd64)
 		architecture="x86_64"
@@ -87,7 +72,23 @@ function get_os_architecture() {
 	echo "${architecture}"
 }
 
-get_plugin_name() {
+function get_os_name() {
+	local os_name
+	case $(uname -s) in
+	Linux*)
+		os_name="linux"
+		;;
+	Darwin*)
+		os_name="darwin"
+		;;
+	*)
+		log_failure_and_exit "Script only supports macOS and Ubuntu"
+		;;
+	esac
+	echo "${os_name}"
+}
+
+function get_plugin_name() {
 	basename "$(dirname "$(dirname "$0")")"
 }
 


### PR DESCRIPTION
Added the correct way to get the architecture

## Description

This maps host's architecture more efficiently and also enables support for native M1 Macs.

## Motivation and Context

To make it work natively on supported architectures.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?

Tested on x86_64 Mac, Ubuntu and M1 Mac.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
