### PR TITLE
feat: support CLOUDSDK_CONFIG env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,12 @@ cloud-firestore-emulator
 
 This file must be named `.default-cloud-sdk-components` and be at one of the following locations:
 
+- `$CLOUDSDK_CONFIG/.default-cloud-sdk-components`: next to gcloud auth configurations
 - `$HOME/.config/gcloud/.default-cloud-sdk-components`: next to gcloud auth configurations
 - `$(dirname ASDF_CONFIG_FILE)/.default-cloud-sdk-components`: relative to `.asdfrc` if configured
 - `$HOME/.default-cloud-sdk-components`: Home dir
+
+> NOTE: by default `CLOUDSDK_CONFIG=$HOME/.config/gcloud`
 
 Below is the list of available components (as of version `342.0.0`):
 

--- a/bin/post-install
+++ b/bin/post-install
@@ -10,7 +10,7 @@ source "${plugin_dir}/lib/utils.bash"
 
 function default_cloud_sdk_components_config_path() {
 	local default_components_filename=".default-cloud-sdk-components"
-	local default_config_dir="$HOME/.config/gcloud"
+	local default_config_dir="$(default_cloud_sdk_config)"
 
 	local asdf_config_path="${ASDF_CONFIG_FILE:-"$HOME/.asdfrc"}"
 	local asdf_config_dir
@@ -30,6 +30,8 @@ function install_default_cloud_sdk_components() {
 	default_cloud_sdk_components="$(default_cloud_sdk_components_config_path)"
 	local gcloud="${ASDF_INSTALL_PATH}/bin/gcloud"
 	declare -a component_list=()
+
+	log_info "ℹ️  Check by Default SDK Components at ${default_cloud_sdk_components}"
 
 	if [ ! -f "$default_cloud_sdk_components" ]; then
 		return

--- a/bin/pre-plugin-remove
+++ b/bin/pre-plugin-remove
@@ -10,4 +10,4 @@ source "${plugin_dir}/lib/utils.bash"
 
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
-log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ${HOME}/.config/gcloud"
+log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory at \"$(default_cloud_sdk_config)\""

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -10,6 +10,6 @@ source "${plugin_dir}/lib/utils.bash"
 
 # Google Cloud SDK uninstall instructions - https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
 
-log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory. Usually ${HOME}/.config/gcloud"
+log_info "ℹ️  Your gcloud project configuration(s) persist in you gcloud configuration directory at \"$(default_cloud_sdk_config)\""
 
 rm -rf "${ASDF_INSTALL_PATH}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -26,7 +26,7 @@ function log_warning() {
 # END Logging
 
 function default_cloud_sdk_config() {
-	echo "${CLOUDSDK_CONFIG:-"$HOME/.config/gcloud"}"
+	printf "%s\\n" "${CLOUDSDK_CONFIG:-"$HOME/.config/gcloud"}"
 }
 
 function check_dependencies() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -25,6 +25,10 @@ function log_warning() {
 }
 # END Logging
 
+function default_cloud_sdk_config() {
+	echo "${CLOUDSDK_CONFIG:-"$HOME/.config/gcloud"}"
+}
+
 function check_dependencies() {
 	local dependencies_file="${1}"
 	local failure_type="${2}" # should be "warning" or "failure"


### PR DESCRIPTION
Add support to use the env `CLOUDSDK_CONFIG` to find `.default-cloud-sdk-components` file to have the same behaviour as `gcloud` SDK.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

```shell
export CLOUDSDK_CONFIG="$HOME/.config/gcloud"
echo 'kubectl' >> $CLOUDSDK_CONFIG/.default-cloud-sdk-components
asdf plugin add gcloud
asdf install gcloud latest
```

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
