### PR TITLE
fix: make `$plugin_dir` absolute path

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-current_script_path="$( cd -- "$(dirname "$BASH_SOURCE[0]")" >/dev/null 2>>"
-plugin_dir="$(dirname "$current_script_path")"
+current_script_dir="$( cd -- "$(dirname "$BASH_SOURCE[0]")" >/dev/null 2>&1 ; pwd -P )"
+plugin_dir="$(dirname "$current_script_dir")"
 
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-current_script_path="${BASH_SOURCE[0]}"
-plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+current_script_path="$( cd -- "$(dirname "$BASH_SOURCE[0]")" >/dev/null 2>>plugin_dir="$(dirname "$current_script_path")"
+plugin_dir="$(dirname "$current_script_path")"
 
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-current_script_path="$( cd -- "$(dirname "$BASH_SOURCE[0]")" >/dev/null 2>>plugin_dir="$(dirname "$current_script_path")"
+current_script_path="$( cd -- "$(dirname "$BASH_SOURCE[0]")" >/dev/null 2>>"
 plugin_dir="$(dirname "$current_script_path")"
 
 # shellcheck source=../lib/utils.bash

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-current_script_dir="$( cd -- "$(dirname "$BASH_SOURCE[0]")" >/dev/null 2>&1 ; pwd -P )"
+current_script_dir="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 plugin_dir="$(dirname "$current_script_dir")"
 
 # shellcheck source=../lib/utils.bash

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
-current_script_dir="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
+current_script_dir="$(
+	cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+	pwd -P
+)"
 plugin_dir="$(dirname "$current_script_dir")"
 
 # shellcheck source=../lib/utils.bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed `$plugin_dir` from relative path to absolute path.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Recent changes in `asdf-direnv` broke compatibility with `asdf-gcloud`. Whenever `direnv` tried to load `gcloud`, it would display the following error:

```shell
direnv: using asdf gcloud 392.0.0
direnv: loading ~/.asdf/plugins/gcloud/bin/exec-env
./exec-env:9: ./lib/utils.bash: No such file or directory
```

Changing `$plugin_dir` from relative path to absolute path in `exec-env` fixes this issue.

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

Same as before.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
