### PR TITLE
fix: fix nextPageToken regexp in list-all, #70

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -22,7 +22,7 @@ function list_all() {
 	local list=""
 	while "${more}"; do
 		res=$(fetch "${nextPageToken}")
-		if [[ "${res}" =~ nextPageToken\"\:\ \"([a-zA-Z0-9]+)\" ]]; then
+		if [[ "${res}" =~ nextPageToken\"\:\ \"([a-zA-Z0-9=]+)\" ]]; then
 			nextPageToken="${BASH_REMATCH[1]}"
 		else
 			more=false


### PR DESCRIPTION
Fix the `nextPageToken` regexp used in `list-all` script preventing to list gcloud versions newer than `403.0.0`. 

## Description

I'm affected by the same issue reported in #70 . Debugging the issue I noticed, the `nextPageToken` returned by the API contains also the `=` characted.

Example:
```json
{
  "kind": "storage#objects",
  "nextPageToken": "AbcdefbGUtY2xvdWQtc2RrLTQwMy4wLjAtbGludXgteDg2XzY0LnRhci5neg==",
   "items": [
```

This PR fixes the regexp to also include the `=` character.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?
 After the change, I can see all the versions properly returned:
```
$ bash bin/list-all
0.9.83 0.9.84 0.9.85 0.9.86 0.9.87 0.9.88 0.9.89 90.0.0 91.0.0 91.0.1 92.0.0 93.0.0 94.0.0 95.0.0 96.0.0 97.0.0 98.0.0 99.0.0 100.0.0 101.0.0 102.0.0 103.0.0 104.0.0 105.0.0 106.0.0 107.0.0 108.0.0 109.0.0 110.0.0 111.0.0 112.0.0 113.0.0 114.0.0 115.0.0 116.0.0 117.0.0 118.0.0 119.0.0 120.0.0 121.0.0 122.0.0 123.0.0 124.0.0 125.0.0 126.0.0 127.0.0 128.0.0 129.0.0 130.0.0 131.0.0 132.0.0 133.0.0 134.0.0 135.0.0 136.0.0 137.0.0 137.0.1 138.0.0 139.0.0 139.0.1 140.0.0 141.0.0 142.0.0 143.0.0 143.0.1 144.0.0 145.0.0 146.0.0 147.0.0 148.0.0 148.0.1 149.0.0 150.0.0 151.0.0 151.0.1 152.0.0 153.0.0 154.0.0 154.0.1 155.0.0 156.0.0 157.0.0 158.0.0 159.0.0 160.0.0 161.0.0 162.0.0 162.0.1 163.0.0 164.0.0 165.0.0 166.0.0 167.0.0 168.0.0 169.0.0 170.0.0 170.0.1 171.0.0 172.0.0 172.0.1 173.0.0 174.0.0 175.0.0 176.0.0 177.0.0 178.0.0 179.0.0 180.0.0 180.0.1 181.0.0 182.0.0 183.0.0 184.0.0 185.0.0 186.0.0 187.0.0 188.0.0 188.0.1 189.0.0 190.0.0 190.0.1 191.0.0 192.0.0 193.0.0 194.0.0 195.0.0 196.0.0 197.0.0 198.0.0 199.0.0 200.0.0 201.0.0 202.0.0 203.0.0 204.0.0 205.0.0 206.0.0 207.0.0 208.0.0 208.0.1 208.0.2 209.0.0 210.0.0 211.0.0 212.0.0 213.0.0 214.0.0 215.0.0 216.0.0 217.0.0 218.0.0 219.0.1 220.0.0 221.0.0 222.0.0 223.0.0 224.0.0 225.0.0 226.0.0 227.0.0 228.0.0 229.0.0 230.0.0 231.0.0 232.0.0 233.0.0 234.0.0 235.0.0 236.0.0 237.0.0 238.0.0 239.0.0 240.0.0 241.0.0 242.0.0 243.0.0 244.0.0 245.0.0 246.0.0 247.0.0 248.0.0 249.0.0 250.0.0 251.0.0 252.0.0 253.0.0 254.0.0 255.0.0 256.0.0 257.0.0 258.0.0 259.0.0 260.0.0 261.0.0 262.0.0 263.0.0 264.0.0 265.0.0 266.0.0 267.0.0 268.0.0 269.0.0 270.0.0 271.0.0 272.0.0 273.0.0 274.0.0 274.0.1 275.0.0 276.0.0 277.0.0 278.0.0 279.0.0 280.0.0 281.0.0 282.0.0 283.0.0 284.0.0 285.0.0 285.0.1 286.0.0 287.0.0 288.0.0 289.0.0 290.0.0 290.0.1 291.0.0 292.0.0 293.0.0 294.0.0 295.0.0 296.0.0 296.0.1 297.0.0 297.0.1 298.0.0 299.0.0 300.0.0 301.0.0 302.0.0 303.0.0 304.0.0 305.0.0 306.0.0 307.0.0 308.0.0 309.0.0 310.0.0 311.0.0 312.0.0 313.0.0 313.0.1 314.0.0 315.0.0 316.0.0 317.0.0 318.0.0 319.0.0 320.0.0 321.0.0 322.0.0 323.0.0 324.0.0 325.0.0 326.0.0 327.0.0 328.0.0 329.0.0 330.0.0 331.0.0 332.0.0 333.0.0 334.0.0 335.0.0 336.0.0 337.0.0 338.0.0 339.0.0 340.0.0 341.0.0 342.0.0 343.0.0 344.0.0 345.0.0 346.0.0 347.0.0 348.0.0 349.0.0 350.0.0 351.0.0 352.0.0 353.0.0 354.0.0 355.0.0 356.0.0 357.0.0 358.0.0 359.0.0 360.0.0 361.0.0 362.0.0 363.0.0 364.0.0 365.0.0 365.0.1 366.0.0 367.0.0 368.0.0 369.0.0 370.0.0 371.0.0 372.0.0 373.0.0 374.0.0 375.0.0 376.0.0 377.0.0 378.0.0 379.0.0 380.0.0 381.0.0 382.0.0 383.0.0 383.0.1 384.0.0 384.0.1 385.0.0 386.0.0 387.0.0 388.0.0 389.0.0 390.0.0 391.0.0 392.0.0 393.0.0 394.0.0 395.0.0 396.0.0 397.0.0 398.0.0 399.0.0 400.0.0 401.0.0 402.0.0 403.0.0 404.0.0 405.0.0 405.0.1 406.0.0 407.0.0 408.0.0 408.0.1 409.0.0
```

<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
