### PR TITLE
fix: kubectl with gke-gcloud-auth-plugin, unbound variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,6 @@ Below is the list of available components (as of version `342.0.0`):
 └───────────────┴──────────────────────────────────────────────────────┴──────────────────────────┴──────────┘
 ```
 
-# FAQ
-
-```
-~/.asdf/lib/commands/command-exec.bash: line 23: shim_args[@]: unbound variable
-```
-
-**This is expected** as `gcloud` requires a command. `asdf-gcloud` sets the Bash option for `nounset` variables which makes running `gcloud` without commands appear as an `asdf` error. You should always pass a command to `gcloud`.
-
 # Contributing
 
 Contributions of any kind welcome! See the [contributing guide](CONTRIBUTING.md).

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 current_script_dir="$(
 	cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 # START Logging
 function log_failure_and_exit() {


### PR DESCRIPTION
Remove forcing all variables to be bound in shell scripts that are run when gcloud commands are executed

## Description

Remove `set -u` option from scripts executed when gcloud commands are executed to support commands without arguments for instance `gke-gcloud-auth-plugin`

## Motivation and Context

gcloud kubectl was not working because it is using command without argument under the hood. 
It fixes [this issue](https://github.com/jthegedus/asdf-gcloud/issues/73)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

`kubectl get pods` without error.

## How Has This Been Tested?

Installed locally and tried to run `kubectl get pods`

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
